### PR TITLE
Request logging & request/response body logging support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # support two latest major versions of Go, following the Go security policy
         # in which these versions get security updates. See https://golang.org/security
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.20.x, 1.21.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS builder
+FROM golang:1.21.1-alpine3.18 AS builder
 
 RUN apk update && apk add --no-cache git
 
@@ -8,7 +8,7 @@ RUN go get ./
 RUN CGO_ENABLED=0 go build -o /app/http-mockery
 RUN chmod +x /app/http-mockery
 
-FROM alpine:latest
+FROM alpine:3.18
 
 COPY --from=builder /app/http-mockery /go/bin/http-mockery
 RUN apk update && apk add --no-cache ca-certificates

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Endpoint config needs to have atleast `uri`, `method` and `response_code` to ope
 
 Endpoint `type` is defaulted to `normal` but can also be set as `regexp`. It allows for standard regular expressions in the `uri` to match more specific use cases. Endpoints are checked in a given order and first matching endpoint (with correct `uri` and `response_code`) will be used.
 
+Request and response bodies from requests can be logged with their relevant config options under `logging`, example [here](examples/config-example.json). Endpoint-specific secrets are censored from logs.
+
+It's also possible to proxy all requests that don't match any endpoint towards a configured destination with [proxy-pass configuration](examples/config-example-proxy-pass.json).
+
 All templates must be valid JSON after variable replacement. No other formats are supported at this time (PRs are welcome!)
-
-## Example usage with Kubernetes
-
-TODO

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ HTTP server returning configurable responses with support for templates.
 
 To run http-mockery you'll need to have a config file. Example is available [here](examples/config-example.json).
 Config file needs to include an `endpoints` config if you want to respond with anything else than 404 Not Found. Default listening address is "0.0.0.0:8080", but this can be changed with `listen_ip` and `listen_port`.
+Default config file is `config.json` in the same directory as the application, but it can also be defined with `HTTP_MOCKERY_CONFIG` env variable.
 
 Endpoint config needs to have atleast `uri`, `method` and `response_code` to operate normally. If you want the endpoint to return any JSON, you'll also need to provide the name of a `template` file, and `variables` configuration if the template includes anything to replace. Replacable variables are marked with < and >, e.g. `<replace_me>`. Matching variable must then be found (see examples). Value can be either provided in the config as `value` or as an environment variable where the env var name should be included in the variable config as `env_var`. Both `value` and `env_var` can be defined, but env_var always has precedence.
 
 Endpoint `type` is defaulted to `normal` but can also be set as `regexp`. It allows for standard regular expressions in the `uri` to match more specific use cases. Endpoints are checked in a given order and first matching endpoint (with correct `uri` and `response_code`) will be used.
 
-Request and response bodies from requests can be logged with their relevant config options under `logging`, example [here](examples/config-example.json). Endpoint-specific secrets are censored from logs.
+Request and response bodies from requests can be logged with their relevant config options under `logging`, example [here](examples/config-example.json). Request & response content logging can also be toggled with env variables `HTTP_MOCKERY_REQUEST_CONTENTS` and `HTTP_MOCKERY_RESPONSE_CONTENTS` Endpoint-specific secrets are censored from logs.
 
 It's also possible to proxy all requests that don't match any endpoint towards a configured destination with [proxy-pass configuration](examples/config-example-proxy-pass.json).
 

--- a/examples/config-example-proxy-pass.json
+++ b/examples/config-example-proxy-pass.json
@@ -9,5 +9,9 @@
   ],
   "listen_port": 8000,
   "listen_ip": "127.0.0.1",
-  "proxy_pass": "https://example.com.localhost/2.0"
+  "proxy_pass": "https://example.com.localhost/2.0",
+  "logging": {
+    "request_contents": true,
+    "response_contents": false
+  }
 }

--- a/examples/config-example.json
+++ b/examples/config-example.json
@@ -31,5 +31,9 @@
       "response_code": 204
     }
   ],
-  "listen_port": 8000
+  "listen_port": 8000,
+  "logging": {
+    "request_contents": true,
+    "response_contents": false
+  }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UpCloudLtd/http-mockery
 
-go 1.19
+go 1.21
 
 require (
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/upcloudltd/http-mockery v0.3.0 h1:aOOSDmfvmdOPdDqGc347namegqYTm0EEBNWvofGWWY0=
-github.com/upcloudltd/http-mockery v0.3.0/go.mod h1:JeJdCs9xN8vCeAIBANRpQTbNSEoukDURxfvproLjspU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 
 	h := mockery.MockHandler{
 		Config: config,
+		Log:    log.Default(),
 	}
 
 	if err = h.ValidateConfig(); err != nil {

--- a/main.go
+++ b/main.go
@@ -11,8 +11,10 @@ import (
 )
 
 const (
-	configEnvName     = "HTTP_MOCKERY_CONFIG"
-	defaultConfigFile = "config.json"
+	EnvVarConfigFile          = "HTTP_MOCKERY_CONFIG"
+	EnvVarLogRequestContents  = "HTTP_MOCKERY_REQUEST_CONTENTS"
+	EnvVarLogResponseContents = "HTTP_MOCKERY_RESPONSE_CONTENTS"
+	defaultConfigFile         = "config.json"
 )
 
 func main() {
@@ -20,7 +22,7 @@ func main() {
 	if len(os.Args) >= 2 {
 		configFile = os.Args[1]
 	}
-	if envConfig, found := os.LookupEnv(configEnvName); found {
+	if envConfig, found := os.LookupEnv(EnvVarConfigFile); found {
 		configFile = envConfig
 	}
 
@@ -34,6 +36,13 @@ func main() {
 	}
 	if config.ListenPort == 0 {
 		config.ListenPort = 8080
+	}
+
+	if _, found := os.LookupEnv(EnvVarLogRequestContents); found {
+		config.Logging.RequestContents = true
+	}
+	if _, found := os.LookupEnv(EnvVarLogResponseContents); found {
+		config.Logging.ResponseContents = true
 	}
 
 	listenAddr := fmt.Sprintf("%s:%d", config.ListenIP, config.ListenPort)
@@ -52,6 +61,6 @@ func main() {
 		log.Fatal("Config validation failed: ", err.Error())
 	}
 
-	log.Printf("start listening %s", listenAddr)
-	log.Fatal(http.Serve(l, h))
+	h.Log.Printf("start listening %s", listenAddr)
+	h.Log.Fatal(http.Serve(l, h))
 }

--- a/pkg/mockery/util.go
+++ b/pkg/mockery/util.go
@@ -1,0 +1,84 @@
+package mockery
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func IsJSON(str string) bool {
+	var js json.RawMessage
+	return json.Unmarshal([]byte(str), &js) == nil
+}
+
+func prettifyJSONBody(body []byte) (string, error) {
+	var prettierJSON bytes.Buffer
+	if err := json.Indent(&prettierJSON, body, "", "  "); err != nil {
+		return "", fmt.Errorf("invalid JSON in body: %w", err)
+	}
+
+	return prettierJSON.String(), nil
+}
+
+func censorVariables(text string, vars []Variable) string {
+	for _, variable := range vars {
+		toReplace := ""
+
+		if variable.Value != "" {
+			toReplace = variable.Value
+		}
+		if variable.EnvVar != "" {
+			envValue, found := os.LookupEnv(variable.EnvVar)
+			if found {
+				toReplace = envValue
+			}
+		}
+
+		if toReplace != "" {
+			text = strings.ReplaceAll(text, toReplace, strings.Repeat("*", len(toReplace)))
+		}
+	}
+
+	return text
+}
+
+func logRequestAndRespond(l *log.Logger, r *http.Request, w http.ResponseWriter, status int, res string, jsonResponse, proxied bool) {
+	logLine := "%s - \"%s %s %s\" %d \"%s\""
+	if proxied {
+		logLine = "Proxied for %s - \"%s %s %s\" %d \"%s\""
+	}
+	l.Printf(logLine, strings.Split(r.RemoteAddr, ":")[0], r.Method, r.RequestURI, r.Proto, status, r.UserAgent())
+	ctx := r.Context()
+	if ctx.Value(ContextKeyReqBody) != nil {
+		l.Printf("Request body for %s %s:\n%s\n", r.Method, r.RequestURI, ctx.Value(ContextKeyReqBody))
+	}
+	if ctx.Value(ContextKeyResBody) != nil {
+		l.Printf("Response body for %s %s:\n%s\n", r.Method, r.RequestURI, ctx.Value(ContextKeyResBody))
+	}
+
+	if jsonResponse && !IsJSON(res) {
+		l.Printf("Response for %s %s is not expected valid JSON: %s\n", r.Method, r.RequestURI, res)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Unknown error has occurred, see logs\n"))
+		return
+	}
+
+	if jsonResponse {
+		w.Header().Set("Content-Type", "application/json")
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(res))
+}
+
+func addToRequestContext(r *http.Request, key, content string) *http.Request {
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, key, content)
+
+	return r.WithContext(ctx)
+}


### PR DESCRIPTION
This PR introduces a logger in HTTP mockery. We also have new config options for logging request body, response body or both. Examples & readme amended to support this.