### PR TITLE
feat(mockery): use HTTP headers as variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ To run http-mockery you'll need to have a config file. Example is available [her
 Config file needs to include an `endpoints` config if you want to respond with anything else than 404 Not Found. Default listening address is "0.0.0.0:8080", but this can be changed with `listen_ip` and `listen_port`.
 Default config file is `config.json` in the same directory as the application, but it can also be defined with `HTTP_MOCKERY_CONFIG` env variable.
 
-Endpoint config needs to have atleast `uri`, `method` and `response_code` to operate normally. If you want the endpoint to return any JSON, you'll also need to provide the name of a `template` file, and `variables` configuration if the template includes anything to replace. Replacable variables are marked with < and >, e.g. `<replace_me>`. Matching variable must then be found (see examples). Value can be either provided in the config as `value` or as an environment variable where the env var name should be included in the variable config as `env_var`. Both `value` and `env_var` can be defined, but env_var always has precedence.
-
+Endpoint config needs to have atleast `uri`, `method` and `response_code` to operate normally. If you want the endpoint to return any JSON, you'll also need to provide the name of a `template` file, and `variables` configuration if the template includes template tags. Replacable variables are marked with `<` and `>` tags, e.g. `<replace_me>`. Matching `env_var` and `value` variables must then be found (see examples), `header` variables are treated as optional.   
+Following template tag value providers are supported (order by priority):
+- `env_var` uses environment variable's value to replace tag
+- `value`, replaces template tag with raw value
+- `header`, uses HTTP request header field value to replace template tag
+ 
 Endpoint `type` is defaulted to `normal` but can also be set as `regexp`. It allows for standard regular expressions in the `uri` to match more specific use cases. Endpoints are checked in a given order and first matching endpoint (with correct `uri` and `response_code`) will be used.
 
 Request and response bodies from requests can be logged with their relevant config options under `logging`, example [here](examples/config-example.json). Request & response content logging can also be toggled with env variables `HTTP_MOCKERY_REQUEST_CONTENTS` and `HTTP_MOCKERY_RESPONSE_CONTENTS` Endpoint-specific secrets are censored from logs.

--- a/examples/config-example.json
+++ b/examples/config-example.json
@@ -14,6 +14,10 @@
         {
           "name": "item2",
           "env_var": "TEMPLATE_VALUE2"
+        },
+        {
+          "name": "item3",
+          "header": "X-Real-IP"
         }
       ]
     },

--- a/pkg/mockery/mockery.go
+++ b/pkg/mockery/mockery.go
@@ -54,6 +54,7 @@ type Endpoint struct {
 type Variable struct {
 	Name   string `json:"name"`
 	EnvVar string `json:"env_var"`
+	Header string `json:"header"`
 	Value  string `json:"value"`
 }
 
@@ -105,7 +106,7 @@ func (s MockHandler) ValidateConfig() error {
 		}
 
 		if endpoint.Template != "" {
-			rendered, err := s.RenderTemplateResponse(endpoint)
+			rendered, err := s.RenderTemplateResponse(endpoint, &http.Request{})
 			if err != nil {
 				return fmt.Errorf("unable to render template %s: %+v", endpoint.Template, err)
 			}
@@ -119,7 +120,7 @@ func (s MockHandler) ValidateConfig() error {
 	return nil
 }
 
-func (s MockHandler) RenderTemplateResponse(e Endpoint) (string, error) {
+func (s MockHandler) RenderTemplateResponse(e Endpoint, r *http.Request) (string, error) {
 	template, err := os.ReadFile(e.Template)
 	if err != nil {
 		return "", err
@@ -130,6 +131,7 @@ func (s MockHandler) RenderTemplateResponse(e Endpoint) (string, error) {
 		return "", fmt.Errorf("unable to parse template %s: %+v", e.Template, err)
 	}
 
+	header := buildHeaderVars(r)
 	return t.ExecuteFuncStringWithErr(func(w io.Writer, tag string) (int, error) {
 		for _, variable := range e.Variables {
 			if tag == variable.Name {
@@ -140,7 +142,14 @@ func (s MockHandler) RenderTemplateResponse(e Endpoint) (string, error) {
 					}
 					return w.Write([]byte(envVar))
 				}
-
+				if variable.Header != "" {
+					if h := header.Get(variable.Header); h != "" {
+						return w.Write([]byte(h))
+					}
+					// Headers are dynamic and only available in runtime, so fail silently if header is not set.
+					s.Log.Printf("HTTP header %s not found for template %s of endpoint %s", variable.Header, e.Template, e.Uri)
+					return 0, nil
+				}
 				if variable.Value != "" {
 					return w.Write([]byte(variable.Value))
 				}
@@ -206,7 +215,7 @@ func (s MockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := s.RenderTemplateResponse(endpoint)
+	resp, err := s.RenderTemplateResponse(endpoint, r)
 	if err != nil {
 		errorHandler(w, r, s.Log, fmt.Sprintf("Unknown error in parsing response for %s (%s)", endpoint.Uri, endpoint.Method), err, false)
 		return
@@ -276,4 +285,16 @@ func OpenConfigFile(path string) (Config, error) {
 func errorHandler(w http.ResponseWriter, r *http.Request, l *log.Logger, msg string, err error, proxied bool) {
 	l.Printf("%s: %v\n", msg, err)
 	logRequestAndRespond(l, r, w, http.StatusInternalServerError, "Unknown error has occurred, see logs\n", false, proxied)
+}
+
+func buildHeaderVars(r *http.Request) http.Header {
+	if r == nil {
+		return http.Header{}
+	}
+	h := r.Header.Clone()
+	if username, password, ok := r.BasicAuth(); ok {
+		h.Set("authorization_username", username)
+		h.Set("authorization_password", password)
+	}
+	return h
 }

--- a/pkg/mockery/mockery.go
+++ b/pkg/mockery/mockery.go
@@ -142,6 +142,9 @@ func (s MockHandler) RenderTemplateResponse(e Endpoint, r *http.Request) (string
 					}
 					return w.Write([]byte(envVar))
 				}
+				if variable.Value != "" {
+					return w.Write([]byte(variable.Value))
+				}
 				if variable.Header != "" {
 					if h := header.Get(variable.Header); h != "" {
 						return w.Write([]byte(h))
@@ -149,9 +152,6 @@ func (s MockHandler) RenderTemplateResponse(e Endpoint, r *http.Request) (string
 					// Headers are dynamic and only available in runtime, so fail silently if header is not set.
 					s.Log.Printf("HTTP header %s not found for template %s of endpoint %s", variable.Header, e.Template, e.Uri)
 					return 0, nil
-				}
-				if variable.Value != "" {
-					return w.Write([]byte(variable.Value))
 				}
 			}
 		}

--- a/test/response-example.json
+++ b/test/response-example.json
@@ -1,5 +1,5 @@
 {
     "status": "success",
-    "configured_var": "<item1>"
+    "configured_var": "<item1>",
+    "username": "<auth_username>"
 }
-  


### PR DESCRIPTION
Use HTTP request headers as template variables. This automatically maps `authorization_username` and `authorization_password` variables that can be used when e.g. mocking account related endpoints. 